### PR TITLE
fix: 修复控制问题

### DIFF
--- a/src/intention-tower-knowledge-graph/Config/config-tabs/CalendarEntry/AddCalendarEntryThisWeek.tid
+++ b/src/intention-tower-knowledge-graph/Config/config-tabs/CalendarEntry/AddCalendarEntryThisWeek.tid
@@ -1,0 +1,3 @@
+title: $:/config/intention-tower-knowledge-graph/ViewTemplate/AddCalendarEntryThisWeek
+
+show

--- a/src/intention-tower-knowledge-graph/Config/config-tabs/CalendarEntry/AddCalendarEntryToday.tid
+++ b/src/intention-tower-knowledge-graph/Config/config-tabs/CalendarEntry/AddCalendarEntryToday.tid
@@ -1,0 +1,3 @@
+title: $:/config/intention-tower-knowledge-graph/ViewTemplate/AddCalendarEntryToday
+
+show

--- a/src/intention-tower-knowledge-graph/Config/config-tabs/CalendarEntry/CalendarThisWeek.tid
+++ b/src/intention-tower-knowledge-graph/Config/config-tabs/CalendarEntry/CalendarThisWeek.tid
@@ -1,0 +1,3 @@
+title: $:/config/intention-tower-knowledge-graph/ViewTemplate/CalendarEntry/CalendarThisWeek
+
+show

--- a/src/intention-tower-knowledge-graph/Config/config-tabs/UnderIntention/AddIntention.tid
+++ b/src/intention-tower-knowledge-graph/Config/config-tabs/UnderIntention/AddIntention.tid
@@ -1,0 +1,3 @@
+title: $:/config/intention-tower-knowledge-graph/ViewTemplate/UnderIntention/AddIntention
+
+show

--- a/src/intention-tower-knowledge-graph/Config/config-tabs/UnderIntention/ProjectDynamicTable.tid
+++ b/src/intention-tower-knowledge-graph/Config/config-tabs/UnderIntention/ProjectDynamicTable.tid
@@ -1,0 +1,3 @@
+title: $:/config/intention-tower-knowledge-graph/ViewTemplate/ProjectDynamicTable
+
+show

--- a/src/intention-tower-knowledge-graph/Config/config-tabs/UnderIntention/ProjectsUnderThisIntentionFlowChartEcharts.tid
+++ b/src/intention-tower-knowledge-graph/Config/config-tabs/UnderIntention/ProjectsUnderThisIntentionFlowChartEcharts.tid
@@ -1,0 +1,3 @@
+title: $:/config/intention-tower-knowledge-graph/ViewTemplate/ProjectsUnderThisIntentionFlowChartEcharts
+
+show

--- a/src/intention-tower-knowledge-graph/Config/config-tabs/UnderProject/AddIntention.tid
+++ b/src/intention-tower-knowledge-graph/Config/config-tabs/UnderProject/AddIntention.tid
@@ -1,0 +1,3 @@
+title: $:/config/intention-tower-knowledge-graph/ViewTemplate/UnderProject/AddIntention
+
+show

--- a/src/intention-tower-knowledge-graph/Config/config-tabs/UnderProject/CalendarThisYear.tid
+++ b/src/intention-tower-knowledge-graph/Config/config-tabs/UnderProject/CalendarThisYear.tid
@@ -1,0 +1,3 @@
+title: $:/config/intention-tower-knowledge-graph/ViewTemplate/CalendarEntry/CalendarThisYear
+
+show

--- a/src/intention-tower-knowledge-graph/Config/config-tabs/UnderProject/TaskDynamicTable.tid
+++ b/src/intention-tower-knowledge-graph/Config/config-tabs/UnderProject/TaskDynamicTable.tid
@@ -1,0 +1,3 @@
+title: $:/config/intention-tower-knowledge-graph/ViewTemplate/TaskDynamicTable
+
+show

--- a/src/intention-tower-knowledge-graph/Config/config-tabs/UnderTask/AddProject.tid
+++ b/src/intention-tower-knowledge-graph/Config/config-tabs/UnderTask/AddProject.tid
@@ -1,0 +1,3 @@
+title: $:/config/intention-tower-knowledge-graph/ViewTemplate/AddProject
+
+show

--- a/src/intention-tower-knowledge-graph/Config/config-tabs/UnderTask/CalendarEntry.tid
+++ b/src/intention-tower-knowledge-graph/Config/config-tabs/UnderTask/CalendarEntry.tid
@@ -1,0 +1,3 @@
+title: $:/config/intention-tower-knowledge-graph/ViewTemplate/CalendarEntry
+
+show

--- a/src/intention-tower-knowledge-graph/Config/config-tabs/UnderTask/TaskContext.tid
+++ b/src/intention-tower-knowledge-graph/Config/config-tabs/UnderTask/TaskContext.tid
@@ -1,0 +1,3 @@
+title: $:/config/intention-tower-knowledge-graph/ViewTemplate/TaskContext
+
+show

--- a/src/intention-tower-knowledge-graph/ControlPanel/Settings.tid
+++ b/src/intention-tower-knowledge-graph/ControlPanel/Settings.tid
@@ -28,10 +28,17 @@ tags: $:/tags/ControlPanel/SettingsTab
 </div>
 \end
 
-<!-- 自定义了一个宏，不然代码复制起来看着太复杂。 -->
+<!-- 改成可config来控制，避免出现无法更新内容的情况 -->
 
-\define itkg-checkbox(name,tags)
-<$checkbox tiddler="$name$"  tag="$tags$"><$link to="$name$" >{{$name$!!caption}}</$link></$checkbox>
+\define itkg-checkbox(configname,realname)
+<$checkbox tiddler="$configname$" field="text" checked="show" unchecked="hide" >
+<$link to="$configname$" >
+config
+</$link>&nbsp;⇨&nbsp;
+<$link to="$realname$" >
+{{$realname$!!caption}}
+</$link>
+</$checkbox>
 \end
 
 <!-- These settings let you customise the behaviour of intention-tower-knowledge-graph plugin. -->
@@ -61,25 +68,49 @@ tags: $:/tags/ControlPanel/SettingsTab
 
 [[Task|$:/tags/ITKG/UnderTask]]
 
-* <<itkg-checkbox "$:/plugins/linonetwo/intention-tower-knowledge-graph/ViewTemplate/AddProject" "$:/tags/ITKG/UnderTask" >>
-* <<itkg-checkbox "$:/plugins/linonetwo/intention-tower-knowledge-graph/ViewTemplate/TaskContext" "$:/tags/ITKG/UnderTask" >>
-* <<itkg-checkbox "$:/plugins/linonetwo/intention-tower-knowledge-graph/ViewTemplate/CalendarEntry" "$:/tags/ITKG/UnderTask" >>
-** <<itkg-checkbox "$:/plugins/linonetwo/intention-tower-knowledge-graph/ViewTemplate/AddCalendarEntryThisWeek" "$:/tags/ITKG/CalendarEntry" >>
-** <<itkg-checkbox "$:/plugins/linonetwo/intention-tower-knowledge-graph/ViewTemplate/AddCalendarEntryToday" "$:/tags/ITKG/CalendarEntry" >>
-** <<itkg-checkbox "$:/plugins/linonetwo/intention-tower-knowledge-graph/ViewTemplate/CalendarEntry/CalendarThisWeek" "$:/tags/ITKG/CalendarEntry" >>
+* <<itkg-checkbox  
+"$:/config/intention-tower-knowledge-graph/ViewTemplate/AddProject"
+"$:/plugins/linonetwo/intention-tower-knowledge-graph/ViewTemplate/AddProject">>
+* <<itkg-checkbox 
+"$:/config/intention-tower-knowledge-graph/ViewTemplate/TaskContext"
+"$:/plugins/linonetwo/intention-tower-knowledge-graph/ViewTemplate/TaskContext"  >>
+* <<itkg-checkbox 
+"$:/config/intention-tower-knowledge-graph/ViewTemplate/CalendarEntry"
+"$:/plugins/linonetwo/intention-tower-knowledge-graph/ViewTemplate/CalendarEntry" >>
+** <<itkg-checkbox 
+"$:/config/intention-tower-knowledge-graph/ViewTemplate/AddCalendarEntryThisWeek"
+"$:/plugins/linonetwo/intention-tower-knowledge-graph/ViewTemplate/AddCalendarEntryThisWeek"  >>
+** <<itkg-checkbox 
+"$:/config/intention-tower-knowledge-graph/ViewTemplate/AddCalendarEntryToday"
+"$:/plugins/linonetwo/intention-tower-knowledge-graph/ViewTemplate/AddCalendarEntryToday"  >>
+** <<itkg-checkbox 
+"$:/config/intention-tower-knowledge-graph/ViewTemplate/CalendarEntry/CalendarThisWeek"
+"$:/plugins/linonetwo/intention-tower-knowledge-graph/ViewTemplate/CalendarEntry/CalendarThisWeek" >>
 
 [[Project|$:/tags/ITKG/UnderProject]]
 
-* <<itkg-checkbox "$:/plugins/linonetwo/intention-tower-knowledge-graph/ViewTemplate/TaskDynamicTable" "$:/tags/ITKG/UnderProject" >>
-* <<itkg-checkbox "$:/plugins/linonetwo/intention-tower-knowledge-graph/ViewTemplate/AddIntention" "$:/tags/ITKG/UnderProject" >>
-* <<itkg-checkbox "$:/plugins/linonetwo/intention-tower-knowledge-graph/ViewTemplate/CalendarEntry/CalendarThisYear" "$:/tags/ITKG/UnderProject" >>
+* <<itkg-checkbox 
+"$:/config/intention-tower-knowledge-graph/ViewTemplate/TaskDynamicTable"
+"$:/plugins/linonetwo/intention-tower-knowledge-graph/ViewTemplate/TaskDynamicTable" >>
+* <<itkg-checkbox 
+"$:/config/intention-tower-knowledge-graph/ViewTemplate/UnderProject/AddIntention"
+"$:/plugins/linonetwo/intention-tower-knowledge-graph/ViewTemplate/UnderProject/AddIntention" >>
+* <<itkg-checkbox 
+"$:/config/intention-tower-knowledge-graph/ViewTemplate/CalendarEntry/CalendarThisYear"
+"$:/plugins/linonetwo/intention-tower-knowledge-graph/ViewTemplate/CalendarEntry/CalendarThisYear" >>
 
 
 [[Intention|$:/tags/ITKG/UnderIntention]]
 
-* <<itkg-checkbox "$:/plugins/linonetwo/intention-tower-knowledge-graph/ViewTemplate/AddIntention" "$:/tags/ITKG/UnderIntention" >>
-* <<itkg-checkbox "$:/plugins/linonetwo/intention-tower-knowledge-graph/ViewTemplate/ProjectDynamicTable" "$:/tags/ITKG/UnderIntention" >>
-* <<itkg-checkbox "$:/plugins/linonetwo/intention-tower-knowledge-graph/ViewTemplate/ProjectsUnderThisIntentionFlowChartEcharts" "$:/tags/ITKG/UnderIntention" >>
+* <<itkg-checkbox 
+"$:/config/intention-tower-knowledge-graph/ViewTemplate/UnderIntention/AddIntention"
+"$:/plugins/linonetwo/intention-tower-knowledge-graph/ViewTemplate/UnderIntention/AddIntention" >>
+* <<itkg-checkbox 
+"$:/config/intention-tower-knowledge-graph/ViewTemplate/ProjectDynamicTable"
+"$:/plugins/linonetwo/intention-tower-knowledge-graph/ViewTemplate/ProjectDynamicTable" >>
+* <<itkg-checkbox 
+"$:/config/intention-tower-knowledge-graph/ViewTemplate/ProjectsUnderThisIntentionFlowChartEcharts"
+"$:/plugins/linonetwo/intention-tower-knowledge-graph/ViewTemplate/ProjectsUnderThisIntentionFlowChartEcharts">>
 
 !! 动态表格字段值，可在下面编辑
 

--- a/src/intention-tower-knowledge-graph/ViewTemplate/UnderIntention/AddIntention.tid
+++ b/src/intention-tower-knowledge-graph/ViewTemplate/UnderIntention/AddIntention.tid
@@ -1,0 +1,7 @@
+title: $:/plugins/linonetwo/intention-tower-knowledge-graph/ViewTemplate/UnderIntention/AddIntention
+caption: {{$:/core/images/tag-button}} 添加意义
+tags: $:/tags/ITKG/UnderIntention
+
+<$reveal state="$:/config/intention-tower-knowledge-graph/ViewTemplate/UnderIntention/AddIntention" type="match" text="show">
+{{||$:/core/ui/EditTemplate/tags}}
+</$reveal>

--- a/src/intention-tower-knowledge-graph/ViewTemplate/UnderIntention/ProjectDynamicTable.tid
+++ b/src/intention-tower-knowledge-graph/ViewTemplate/UnderIntention/ProjectDynamicTable.tid
@@ -4,4 +4,8 @@ tags: $:/tags/ITKG/UnderIntention
 
 \import [[$:/plugins/linonetwo/intention-tower-knowledge-graph/filters/leaf-task]]
 
+<$reveal state="$:/config/intention-tower-knowledge-graph/ViewTemplate/ProjectDynamicTable" type="match" text="show">
+
 <$macrocall $name=aggregation caption="项目列表" filter=<<get-non-completed-leaf-projects>> defaultFields={{$:/plugins/linonetwo/intention-tower-knowledge-graph/Config/defaultFields-ProjectDynamicTable}} class="w-100" state="ITKG-ProjectDynamicTable-state" />
+
+</$reveal>

--- a/src/intention-tower-knowledge-graph/ViewTemplate/UnderIntention/ProjectsUnderThisIntentionFlowChartEcharts.tid
+++ b/src/intention-tower-knowledge-graph/ViewTemplate/UnderIntention/ProjectsUnderThisIntentionFlowChartEcharts.tid
@@ -11,4 +11,8 @@ tags: $:/tags/ITKG/UnderIntention
 />
 \end
 
+<$reveal state="$:/config/intention-tower-knowledge-graph/ViewTemplate/ProjectsUnderThisIntentionFlowChartEcharts" type="match" text="show">
+
 <<echarts-with-subfilter>>
+
+</$reveal>

--- a/src/intention-tower-knowledge-graph/ViewTemplate/UnderProject/AddIntention.tid
+++ b/src/intention-tower-knowledge-graph/ViewTemplate/UnderProject/AddIntention.tid
@@ -1,5 +1,7 @@
-title: $:/plugins/linonetwo/intention-tower-knowledge-graph/ViewTemplate/AddIntention
+title: $:/plugins/linonetwo/intention-tower-knowledge-graph/ViewTemplate/UnderProject/AddIntention
 caption: {{$:/core/images/tag-button}} 添加意义
-tags: $:/tags/ITKG/UnderProject $:/tags/ITKG/UnderIntention
+tags: $:/tags/ITKG/UnderProject
 
+<$reveal state="$:/config/intention-tower-knowledge-graph/ViewTemplate/UnderProject/AddIntention" type="match" text="show">
 {{||$:/core/ui/EditTemplate/tags}}
+</$reveal>

--- a/src/intention-tower-knowledge-graph/ViewTemplate/UnderProject/CalendarThisYear.tid
+++ b/src/intention-tower-knowledge-graph/ViewTemplate/UnderProject/CalendarThisYear.tid
@@ -8,6 +8,8 @@ tags: $:/tags/ITKG/UnderProject
 <$calendar filter="[all[]in-tagtree-of:inclusive[$currentTag$]field:calendarEntry[yes]]" readonly="yes" initialView="listYear" hideToolbar="yes" />
 \end
 
+<$reveal state="$:/config/intention-tower-knowledge-graph/ViewTemplate/CalendarEntry/CalendarThisYear" type="match" text="show">
+
 项目下共工作 {{{ 
 [all[]in-tagtree-of:inclusive<currentTiddler>field:calendarEntry[yes]]
   :map[subfilter<getTimeForEntry>]
@@ -16,3 +18,5 @@ tags: $:/tags/ITKG/UnderProject
 
 
 <$macrocall $name="calendarWithCurrentTiddler" currentTag=<<currentTiddler>>/>
+
+</$reveal>

--- a/src/intention-tower-knowledge-graph/ViewTemplate/UnderProject/TaskDynamicTable.tid
+++ b/src/intention-tower-knowledge-graph/ViewTemplate/UnderProject/TaskDynamicTable.tid
@@ -5,4 +5,8 @@ tags: $:/tags/ITKG/UnderProject
 \import [[$:/plugins/linonetwo/intention-tower-knowledge-graph/filters/leaf-task]]
 
 \define caption() 优先待办列表 <$count filter=<<get-non-completed-leaf-tasks>> />
+<$reveal state="$:/config/intention-tower-knowledge-graph/ViewTemplate/TaskDynamicTable" type="match" text="show">
+
 <$macrocall $name=aggregation caption=<<caption>> filter=<<get-non-completed-leaf-tasks>> defaultFields={{$:/plugins/linonetwo/intention-tower-knowledge-graph/Config/defaultFields-TaskDynamicTable}} class="w-100" state="ITKG-TaskDynamicTable-state" />
+
+</$reveal>

--- a/src/intention-tower-knowledge-graph/ViewTemplate/UnderTask/AddProject.tid
+++ b/src/intention-tower-knowledge-graph/ViewTemplate/UnderTask/AddProject.tid
@@ -2,4 +2,8 @@ title: $:/plugins/linonetwo/intention-tower-knowledge-graph/ViewTemplate/AddProj
 caption: {{$:/core/images/tag-button}} 添加所在项目
 tags: $:/tags/ITKG/UnderTask
 
+<$reveal state="$:/config/intention-tower-knowledge-graph/ViewTemplate/AddProject" type="match" text="show">
+
 {{||$:/core/ui/EditTemplate/tags}}
+
+</$reveal>

--- a/src/intention-tower-knowledge-graph/ViewTemplate/UnderTask/CalendarEntry/AddCalendarEntryThisWeek.tid
+++ b/src/intention-tower-knowledge-graph/ViewTemplate/UnderTask/CalendarEntry/AddCalendarEntryThisWeek.tid
@@ -2,4 +2,8 @@ title: $:/plugins/linonetwo/intention-tower-knowledge-graph/ViewTemplate/AddCale
 caption: {{$:/plugins/linonetwo/tw-calendar/Images/CalendarWeek}} 调整本周任务
 tags: $:/tags/ITKG/CalendarEntry
 
+<$reveal state="$:/config/intention-tower-knowledge-graph/ViewTemplate/AddCalendarEntryThisWeek" type="match" text="show">
+
 <$calendar defaultTags={{{ [<currentTiddler>] [{$:/plugins/linonetwo/intention-tower-knowledge-graph/Config/default-calendar-entry-tag}] +[join[ ]] }}} hideToolbar="yes" height="600px" initialView="timeGridWeek" filter="[all[tiddlers]!is[system]field:calendarEntry[yes]]" />
+
+</$reveal>

--- a/src/intention-tower-knowledge-graph/ViewTemplate/UnderTask/CalendarEntry/AddCalendarEntryToday.tid
+++ b/src/intention-tower-knowledge-graph/ViewTemplate/UnderTask/CalendarEntry/AddCalendarEntryToday.tid
@@ -4,6 +4,8 @@ tags: $:/tags/ITKG/CalendarEntry
 
 \import [[$:/plugins/linonetwo/intention-tower-knowledge-graph/filters/time]]
 
+<$reveal state="$:/config/intention-tower-knowledge-graph/ViewTemplate/AddCalendarEntryToday" type="match" text="show">
+
 今日仅工作 {{{ 
 [all[]tag<currentTiddler>days:startDate[0]field:calendarEntry[yes]]
   :map[subfilter<getTimeForEntry>]
@@ -11,3 +13,5 @@ tags: $:/tags/ITKG/CalendarEntry
 }}} 小时！（包含计划中未做的）
 
 <$calendar defaultTags={{{ [<currentTiddler>] [{$:/plugins/linonetwo/intention-tower-knowledge-graph/Config/default-calendar-entry-tag}] +[join[ ]] }}} hideToolbar="yes" height="600px" initialView="timeGridDay" filter="[all[tiddlers]!is[system]days:startDate[0]field:calendarEntry[yes]]" />
+
+</$reveal>

--- a/src/intention-tower-knowledge-graph/ViewTemplate/UnderTask/CalendarEntry/CalendarEntry.tid
+++ b/src/intention-tower-knowledge-graph/ViewTemplate/UnderTask/CalendarEntry/CalendarEntry.tid
@@ -2,4 +2,8 @@ title: $:/plugins/linonetwo/intention-tower-knowledge-graph/ViewTemplate/Calenda
 caption: {{$:/plugins/linonetwo/tw-calendar/tiddlywiki-ui/Images/GoToCalendarImage}} 日历记录
 tags: $:/tags/ITKG/UnderTask
 
+<$reveal state="$:/config/intention-tower-knowledge-graph/ViewTemplate/CalendarEntry" type="match" text="show">
+
 <<tabs "[all[tiddlers+shadows]tag[$:/tags/ITKG/CalendarEntry]]" "$:/plugins/linonetwo/intention-tower-knowledge-graph/ViewTemplate/AddCalendarEntryToday" >>
+
+</$reveal>

--- a/src/intention-tower-knowledge-graph/ViewTemplate/UnderTask/CalendarEntry/CalendarThisWeek.tid
+++ b/src/intention-tower-knowledge-graph/ViewTemplate/UnderTask/CalendarEntry/CalendarThisWeek.tid
@@ -6,4 +6,6 @@ tags: $:/tags/ITKG/CalendarEntry
 <$calendar filter="[all[]tag[$currentTag$]field:calendarEntry[yes]]" readonly="yes" initialView="listWeek" hideToolbar="yes" />
 \end
 
+<$reveal state="$:/config/intention-tower-knowledge-graph/ViewTemplate/CalendarEntry/CalendarThisWeek" type="match" text="show">
 <$macrocall $name="calendarWithCurrentTiddler" currentTag=<<currentTiddler>>/>
+</$reveal>

--- a/src/intention-tower-knowledge-graph/ViewTemplate/UnderTask/TaskContext.tid
+++ b/src/intention-tower-knowledge-graph/ViewTemplate/UnderTask/TaskContext.tid
@@ -13,6 +13,8 @@ tags: $:/tags/ITKG/UnderTask
 />
 \end
 
+<$reveal state="$:/config/intention-tower-knowledge-graph/ViewTemplate/TaskContext" type="match" text="show">
+
 <!-- Show all parent tags of current tiddler (all tiddlers that with current tiddler in the tags tree), that with Task, Intention, and Project, but exclude these meta tags themselves -->
 <$list filter="[all[current]tagstree[]!is[system]tag{$:/plugins/linonetwo/intention-tower-knowledge-graph/Config/task-tag}] :or[all[current]tagstree[]!is[system]tag{$:/plugins/linonetwo/intention-tower-knowledge-graph/Config/intention-tag}] -[{$:/plugins/linonetwo/intention-tower-knowledge-graph/Config/task-tag}] -[{$:/plugins/linonetwo/intention-tower-knowledge-graph/Config/project-tag}] -[{$:/plugins/linonetwo/intention-tower-knowledge-graph/Config/intention-tag}]" counter="counter1">
   <$link><<currentTiddler>></$link>
@@ -55,3 +57,5 @@ tags: $:/tags/ITKG/UnderTask
 <$list filter="[<graphRootTiddler>taggingtree[]filter<filter-is-new-task>count[]compare:number:gt[0]then[yes]]">
   <$flowchart tiddler=<<graphRootTiddler>> height="600px" $template-tags={{$:/plugins/linonetwo/intention-tower-knowledge-graph/Config/task-tag}} subfilter="[filter<filter-is-new-task>]" />
 </$list>
+
+</$reveal>

--- a/src/intention-tower-knowledge-graph/plugin.info
+++ b/src/intention-tower-knowledge-graph/plugin.info
@@ -6,5 +6,5 @@
   "plugin-type": "plugin",
   "version": "0.4.3",
   "dependents": ["$:/plugins/kookma/shiraz", "$:/plugins/linonetwo/flow-chart", "$:/plugins/yaisog/taggingtree-filter", "$:/plugins/yaisog/tagstree-filter", "$:/plugins/linonetwo/in-tagtree-of", "$:/plugins/Gk0Wk/echarts", "$:/plugins/linonetwo/super-tag", "$:/plugins/linonetwo/tw-calendar", "$:/plugins/xp/aggregation","$:/plugins/kixam/datepicker","$:/plugins/kixam/moment"],
-  "list": "readme ControlPanel/Settings TMO"
+  "list": "readme ControlPanel/Settings TMO tree"
 }

--- a/src/intention-tower-knowledge-graph/tree.tid
+++ b/src/intention-tower-knowledge-graph/tree.tid
@@ -1,0 +1,5 @@
+title: $:/plugins/linonetwo/intention-tower-knowledge-graph/tree
+creator: LinOnetwo
+type: text/vnd.tiddlywiki
+
+<<tree prefix:"$:/plugins/linonetwo/intention-tower-knowledge-graph">>


### PR DESCRIPTION
增加了reveal进行控制。同时把原来的$:/plugins/linonetwo/intention-tower-knowledge-graph/ViewTemplate/AddIntention，拆分成两个条目，一个放在项目下面，一个放在意义下面。避免冲突。

同时增加了一个tree，方便别人查看。

检查没问题的话，应该就可以发一个新版本了。避免别人使用出现错误。