### PR TITLE
fix: 修复tabs控制问题，修复超级标签追踪问题

### DIFF
--- a/src/intention-tower-knowledge-graph/Config/config-tabs/CalendarEntry.tid
+++ b/src/intention-tower-knowledge-graph/Config/config-tabs/CalendarEntry.tid
@@ -1,0 +1,2 @@
+title: $:/config/ViewTemplate/CalendarEntry
+

--- a/src/intention-tower-knowledge-graph/Config/config-tabs/CalendarEntry/AddCalendarEntryThisWeek.tid
+++ b/src/intention-tower-knowledge-graph/Config/config-tabs/CalendarEntry/AddCalendarEntryThisWeek.tid
@@ -1,3 +1,0 @@
-title: $:/config/intention-tower-knowledge-graph/ViewTemplate/AddCalendarEntryThisWeek
-
-show

--- a/src/intention-tower-knowledge-graph/Config/config-tabs/CalendarEntry/AddCalendarEntryToday.tid
+++ b/src/intention-tower-knowledge-graph/Config/config-tabs/CalendarEntry/AddCalendarEntryToday.tid
@@ -1,3 +1,0 @@
-title: $:/config/intention-tower-knowledge-graph/ViewTemplate/AddCalendarEntryToday
-
-show

--- a/src/intention-tower-knowledge-graph/Config/config-tabs/CalendarEntry/CalendarThisWeek.tid
+++ b/src/intention-tower-knowledge-graph/Config/config-tabs/CalendarEntry/CalendarThisWeek.tid
@@ -1,3 +1,0 @@
-title: $:/config/intention-tower-knowledge-graph/ViewTemplate/CalendarEntry/CalendarThisWeek
-
-show

--- a/src/intention-tower-knowledge-graph/Config/config-tabs/ProjectsOverview.tid
+++ b/src/intention-tower-knowledge-graph/Config/config-tabs/ProjectsOverview.tid
@@ -1,0 +1,2 @@
+title: $:/config/ViewTemplate/ProjectsOverview
+

--- a/src/intention-tower-knowledge-graph/Config/config-tabs/UnderIntention.tid
+++ b/src/intention-tower-knowledge-graph/Config/config-tabs/UnderIntention.tid
@@ -1,0 +1,2 @@
+title: $:/config/ViewTemplate/UnderIntention
+

--- a/src/intention-tower-knowledge-graph/Config/config-tabs/UnderIntention/AddIntention.tid
+++ b/src/intention-tower-knowledge-graph/Config/config-tabs/UnderIntention/AddIntention.tid
@@ -1,3 +1,0 @@
-title: $:/config/intention-tower-knowledge-graph/ViewTemplate/UnderIntention/AddIntention
-
-show

--- a/src/intention-tower-knowledge-graph/Config/config-tabs/UnderIntention/ProjectDynamicTable.tid
+++ b/src/intention-tower-knowledge-graph/Config/config-tabs/UnderIntention/ProjectDynamicTable.tid
@@ -1,3 +1,0 @@
-title: $:/config/intention-tower-knowledge-graph/ViewTemplate/ProjectDynamicTable
-
-show

--- a/src/intention-tower-knowledge-graph/Config/config-tabs/UnderIntention/ProjectsUnderThisIntentionFlowChartEcharts.tid
+++ b/src/intention-tower-knowledge-graph/Config/config-tabs/UnderIntention/ProjectsUnderThisIntentionFlowChartEcharts.tid
@@ -1,3 +1,0 @@
-title: $:/config/intention-tower-knowledge-graph/ViewTemplate/ProjectsUnderThisIntentionFlowChartEcharts
-
-show

--- a/src/intention-tower-knowledge-graph/Config/config-tabs/UnderProject.tid
+++ b/src/intention-tower-knowledge-graph/Config/config-tabs/UnderProject.tid
@@ -1,0 +1,2 @@
+title: $:/config/ViewTemplate/UnderProject
+

--- a/src/intention-tower-knowledge-graph/Config/config-tabs/UnderProject/AddIntention.tid
+++ b/src/intention-tower-knowledge-graph/Config/config-tabs/UnderProject/AddIntention.tid
@@ -1,3 +1,0 @@
-title: $:/config/intention-tower-knowledge-graph/ViewTemplate/UnderProject/AddIntention
-
-show

--- a/src/intention-tower-knowledge-graph/Config/config-tabs/UnderProject/CalendarThisYear.tid
+++ b/src/intention-tower-knowledge-graph/Config/config-tabs/UnderProject/CalendarThisYear.tid
@@ -1,3 +1,0 @@
-title: $:/config/intention-tower-knowledge-graph/ViewTemplate/CalendarEntry/CalendarThisYear
-
-show

--- a/src/intention-tower-knowledge-graph/Config/config-tabs/UnderProject/TaskDynamicTable.tid
+++ b/src/intention-tower-knowledge-graph/Config/config-tabs/UnderProject/TaskDynamicTable.tid
@@ -1,3 +1,0 @@
-title: $:/config/intention-tower-knowledge-graph/ViewTemplate/TaskDynamicTable
-
-show

--- a/src/intention-tower-knowledge-graph/Config/config-tabs/UnderTask.tid
+++ b/src/intention-tower-knowledge-graph/Config/config-tabs/UnderTask.tid
@@ -1,0 +1,2 @@
+title: $:/config/ViewTemplate/UnderTask
+

--- a/src/intention-tower-knowledge-graph/Config/config-tabs/UnderTask/AddProject.tid
+++ b/src/intention-tower-knowledge-graph/Config/config-tabs/UnderTask/AddProject.tid
@@ -1,3 +1,0 @@
-title: $:/config/intention-tower-knowledge-graph/ViewTemplate/AddProject
-
-show

--- a/src/intention-tower-knowledge-graph/Config/config-tabs/UnderTask/CalendarEntry.tid
+++ b/src/intention-tower-knowledge-graph/Config/config-tabs/UnderTask/CalendarEntry.tid
@@ -1,3 +1,0 @@
-title: $:/config/intention-tower-knowledge-graph/ViewTemplate/CalendarEntry
-
-show

--- a/src/intention-tower-knowledge-graph/Config/config-tabs/UnderTask/TaskContext.tid
+++ b/src/intention-tower-knowledge-graph/Config/config-tabs/UnderTask/TaskContext.tid
@@ -1,3 +1,0 @@
-title: $:/config/intention-tower-knowledge-graph/ViewTemplate/TaskContext
-
-show

--- a/src/intention-tower-knowledge-graph/Config/task-tag.tid
+++ b/src/intention-tower-knowledge-graph/Config/task-tag.tid
@@ -1,3 +1,4 @@
 title: $:/plugins/linonetwo/intention-tower-knowledge-graph/Config/task-tag
+tags: $:/TraitTag/TMO/Task
 
 任务

--- a/src/intention-tower-knowledge-graph/ControlPanel/Fields.tid
+++ b/src/intention-tower-knowledge-graph/ControlPanel/Fields.tid
@@ -1,0 +1,22 @@
+title: $:/plugins/linonetwo/intention-tower-knowledge-graph/Settings/Fields
+caption: Fields
+tags: $:/tags/intention-tower-knowledge-graph/Settings
+order: 3
+
+!! 动态表格字段值，可在下面编辑
+
+[[人生意义|$:/plugins/linonetwo/intention-tower-knowledge-graph/Config/defaultFields-IntentionDynamicTable]]的值：{{$:/plugins/linonetwo/intention-tower-knowledge-graph/Config/defaultFields-IntentionDynamicTable}}
+
+<$edit-text tiddler="$:/plugins/linonetwo/intention-tower-knowledge-graph/Config/defaultFields-IntentionDynamicTable" field="text" tag=input class="w-100" />
+
+[[优先任务列表|$:/plugins/linonetwo/intention-tower-knowledge-graph/Config/defaultFields-PriorityTaskDynamicTable]]的值：{{$:/plugins/linonetwo/intention-tower-knowledge-graph/Config/defaultFields-PriorityTaskDynamicTable}}
+
+<$edit-text tiddler="$:/plugins/linonetwo/intention-tower-knowledge-graph/Config/defaultFields-PriorityTaskDynamicTable" field="text" tag=input class="w-100" />
+
+[[项目列表|$:/plugins/linonetwo/intention-tower-knowledge-graph/Config/defaultFields-ProjectDynamicTable]]的值：{{$:/plugins/linonetwo/intention-tower-knowledge-graph/Config/defaultFields-ProjectDynamicTable}}
+
+<$edit-text tiddler="$:/plugins/linonetwo/intention-tower-knowledge-graph/Config/defaultFields-ProjectDynamicTable" field="text" tag=input class="w-100" />
+
+[[任务列表|$:/plugins/linonetwo/intention-tower-knowledge-graph/Config/defaultFields-TaskDynamicTable]]的值：{{$:/plugins/linonetwo/intention-tower-knowledge-graph/Config/defaultFields-TaskDynamicTable}}
+
+<$edit-text tiddler="$:/plugins/linonetwo/intention-tower-knowledge-graph/Config/defaultFields-TaskDynamicTable" field="text" tag=input class="w-100" />

--- a/src/intention-tower-knowledge-graph/ControlPanel/Settings.tid
+++ b/src/intention-tower-knowledge-graph/ControlPanel/Settings.tid
@@ -2,130 +2,14 @@ title: $:/plugins/linonetwo/intention-tower-knowledge-graph/ControlPanel/Setting
 caption: ITKG
 tags: $:/tags/ControlPanel/SettingsTab
 
-\define single-text-tag-editor(typeName)
-\whitespace trim
-<div class="itkg-setting-tags-item">
-  <$let
-    currentTiddler="$:/plugins/linonetwo/intention-tower-knowledge-graph/Config/$typeName$-tag"
-    palette={{$:/palette}}
-    tempTitle=<<qualify "edit-$typeName$">>
-    tabIndex={{$:/config/EditTabIndex}}
-    cancelPopups="yes"
-  >
-    <$macrocall $name="tag" tag={{$:/plugins/linonetwo/intention-tower-knowledge-graph/Config/$typeName$-tag}} />
 
-    <$edit-text tiddler=<<tempTitle>> tag="input" field="text" placeholder={{$:/language/EditTemplate/Tags/Add/Placeholder}} />
-
-    <$button>
-      <$action-setfield tiddler=<<currentTiddler>> text={{{ [<tempTitle>get[text]] }}}>
-        <$action-setfield tiddler=<<tempTitle>> text="" />
-      </$action-setfield>
-
-      {{$:/language/EditTemplate/Tags/Add/Button}}
-    </$button>
-    
-  </$let> 
-</div>
-\end
 
 <!-- 改成可config来控制，避免出现无法更新内容的情况 -->
-
-\define itkg-checkbox(configname,realname)
-<$checkbox tiddler="$configname$" field="text" checked="show" unchecked="hide" >
-<$link to="$configname$" >
-config
-</$link>&nbsp;⇨&nbsp;
-<$link to="$realname$" >
-{{$realname$!!caption}}
-</$link>
-</$checkbox>
-\end
-
+<!-- 删除了原来定义的checkbox宏 -->
 <!-- These settings let you customise the behaviour of intention-tower-knowledge-graph plugin. -->
 
 这些设置让你可以自定义 ITKG 插件。
 
 ---
 
-!! 标签
-
-!!! 标注项目关键节点的标签
-
-
-意义：<<single-text-tag-editor intention>>
-
-项目：<<single-text-tag-editor project>>
-
-任务：<<single-text-tag-editor task>>
-
-!!! 新建日历记录时的标签
-
-在新建和一个任务相关的日历项目时，可以设置自动添加日历项目的类型标签，例如「解决问题」。
-
-日历记录额外标签：<<single-text-tag-editor default-calendar-entry>>
-
-!! 可选的选项卡内容
-
-[[Task|$:/tags/ITKG/UnderTask]]
-
-* <<itkg-checkbox  
-"$:/config/intention-tower-knowledge-graph/ViewTemplate/AddProject"
-"$:/plugins/linonetwo/intention-tower-knowledge-graph/ViewTemplate/AddProject">>
-* <<itkg-checkbox 
-"$:/config/intention-tower-knowledge-graph/ViewTemplate/TaskContext"
-"$:/plugins/linonetwo/intention-tower-knowledge-graph/ViewTemplate/TaskContext"  >>
-* <<itkg-checkbox 
-"$:/config/intention-tower-knowledge-graph/ViewTemplate/CalendarEntry"
-"$:/plugins/linonetwo/intention-tower-knowledge-graph/ViewTemplate/CalendarEntry" >>
-** <<itkg-checkbox 
-"$:/config/intention-tower-knowledge-graph/ViewTemplate/AddCalendarEntryThisWeek"
-"$:/plugins/linonetwo/intention-tower-knowledge-graph/ViewTemplate/AddCalendarEntryThisWeek"  >>
-** <<itkg-checkbox 
-"$:/config/intention-tower-knowledge-graph/ViewTemplate/AddCalendarEntryToday"
-"$:/plugins/linonetwo/intention-tower-knowledge-graph/ViewTemplate/AddCalendarEntryToday"  >>
-** <<itkg-checkbox 
-"$:/config/intention-tower-knowledge-graph/ViewTemplate/CalendarEntry/CalendarThisWeek"
-"$:/plugins/linonetwo/intention-tower-knowledge-graph/ViewTemplate/CalendarEntry/CalendarThisWeek" >>
-
-[[Project|$:/tags/ITKG/UnderProject]]
-
-* <<itkg-checkbox 
-"$:/config/intention-tower-knowledge-graph/ViewTemplate/TaskDynamicTable"
-"$:/plugins/linonetwo/intention-tower-knowledge-graph/ViewTemplate/TaskDynamicTable" >>
-* <<itkg-checkbox 
-"$:/config/intention-tower-knowledge-graph/ViewTemplate/UnderProject/AddIntention"
-"$:/plugins/linonetwo/intention-tower-knowledge-graph/ViewTemplate/UnderProject/AddIntention" >>
-* <<itkg-checkbox 
-"$:/config/intention-tower-knowledge-graph/ViewTemplate/CalendarEntry/CalendarThisYear"
-"$:/plugins/linonetwo/intention-tower-knowledge-graph/ViewTemplate/CalendarEntry/CalendarThisYear" >>
-
-
-[[Intention|$:/tags/ITKG/UnderIntention]]
-
-* <<itkg-checkbox 
-"$:/config/intention-tower-knowledge-graph/ViewTemplate/UnderIntention/AddIntention"
-"$:/plugins/linonetwo/intention-tower-knowledge-graph/ViewTemplate/UnderIntention/AddIntention" >>
-* <<itkg-checkbox 
-"$:/config/intention-tower-knowledge-graph/ViewTemplate/ProjectDynamicTable"
-"$:/plugins/linonetwo/intention-tower-knowledge-graph/ViewTemplate/ProjectDynamicTable" >>
-* <<itkg-checkbox 
-"$:/config/intention-tower-knowledge-graph/ViewTemplate/ProjectsUnderThisIntentionFlowChartEcharts"
-"$:/plugins/linonetwo/intention-tower-knowledge-graph/ViewTemplate/ProjectsUnderThisIntentionFlowChartEcharts">>
-
-!! 动态表格字段值，可在下面编辑
-
-[[人生意义|$:/plugins/linonetwo/intention-tower-knowledge-graph/Config/defaultFields-IntentionDynamicTable]]的值：{{$:/plugins/linonetwo/intention-tower-knowledge-graph/Config/defaultFields-IntentionDynamicTable}}
-
-<$edit-text tiddler="$:/plugins/linonetwo/intention-tower-knowledge-graph/Config/defaultFields-IntentionDynamicTable" field="text" tag=input class="w-100" />
-
-[[优先任务列表|$:/plugins/linonetwo/intention-tower-knowledge-graph/Config/defaultFields-PriorityTaskDynamicTable]]的值：{{$:/plugins/linonetwo/intention-tower-knowledge-graph/Config/defaultFields-PriorityTaskDynamicTable}}
-
-<$edit-text tiddler="$:/plugins/linonetwo/intention-tower-knowledge-graph/Config/defaultFields-PriorityTaskDynamicTable" field="text" tag=input class="w-100" />
-
-[[项目列表|$:/plugins/linonetwo/intention-tower-knowledge-graph/Config/defaultFields-ProjectDynamicTable]]的值：{{$:/plugins/linonetwo/intention-tower-knowledge-graph/Config/defaultFields-ProjectDynamicTable}}
-
-<$edit-text tiddler="$:/plugins/linonetwo/intention-tower-knowledge-graph/Config/defaultFields-ProjectDynamicTable" field="text" tag=input class="w-100" />
-
-[[任务列表|$:/plugins/linonetwo/intention-tower-knowledge-graph/Config/defaultFields-TaskDynamicTable]]的值：{{$:/plugins/linonetwo/intention-tower-knowledge-graph/Config/defaultFields-TaskDynamicTable}}
-
-<$edit-text tiddler="$:/plugins/linonetwo/intention-tower-knowledge-graph/Config/defaultFields-TaskDynamicTable" field="text" tag=input class="w-100" />
+<<tabs "[all[shadows+tiddlers]tag[$:/tags/intention-tower-knowledge-graph/Settings]sort[order]]" "$:/plugins/linonetwo/intention-tower-knowledge-graph/Settings/Tags" "$:/state/tab/intention-tower-knowledge-graph/Settings" "tc-vertical">>

--- a/src/intention-tower-knowledge-graph/ControlPanel/Tabs.tid
+++ b/src/intention-tower-knowledge-graph/ControlPanel/Tabs.tid
@@ -1,0 +1,60 @@
+title: $:/plugins/linonetwo/intention-tower-knowledge-graph/Settings/Tabs
+caption: Tabs
+tags: $:/tags/intention-tower-knowledge-graph/Settings
+order: 2
+
+!! 可选的选项卡内容
+
+''如果不想要某个选项内容，点击右边的复制按钮复制条目标题然后粘贴到上面的空白框中，多个条目中间添加空格。''
+
+[[Task|$:/tags/ITKG/UnderTask]]&nbsp;&nbsp;[[config|$:/config/ViewTemplate/UnderTask]]
+
+<$edit-text tiddler="$:/config/ViewTemplate/UnderTask" field="text" tag=textarea class="w-100" />
+
+<$list filter="[all[shadows+tiddlers]tag[$:/tags/ITKG/UnderTask]]">
+
+<$link>{{!!caption}}</$link>&nbsp;&nbsp;&nbsp;<$macrocall $name="copy-to-clipboard" src={{!!title}} />
+
+</$list>
+
+[[Project|$:/tags/ITKG/UnderProject]]&nbsp;&nbsp;[[config|$:/config/ViewTemplate/UnderProject]]
+
+<$edit-text tiddler="$:/config/ViewTemplate/UnderProject" field="text" tag=textarea class="w-100" />
+
+<$list filter="[all[shadows+tiddlers]tag[$:/tags/ITKG/UnderProject]]">
+
+<$link>{{!!caption}}</$link>&nbsp;&nbsp;&nbsp;<$macrocall $name="copy-to-clipboard" src={{!!title}} />
+
+</$list>
+
+
+[[Intention|$:/tags/ITKG/UnderIntention]]&nbsp;&nbsp;[[config|$:/config/ViewTemplate/UnderIntention]]
+
+<$edit-text tiddler="$:/config/ViewTemplate/UnderIntention" field="text" tag=textarea class="w-100" />
+
+<$list filter="[all[shadows+tiddlers]tag[$:/tags/ITKG/UnderIntention]]">
+
+<$link>{{!!caption}}</$link>&nbsp;&nbsp;&nbsp;<$macrocall $name="copy-to-clipboard" src={{!!title}} />
+
+</$list>
+
+[[CalendarEntry|$:/tags/ITKG/CalendarEntry]]&nbsp;&nbsp;[[config|$:/config/ViewTemplate/CalendarEntry]]
+
+<$edit-text tiddler="$:/config/ViewTemplate/CalendarEntry" field="text" tag=textarea class="w-100" />
+
+<$list filter="[all[shadows+tiddlers]tag[$:/tags/ITKG/CalendarEntry]]">
+
+<$link>{{!!caption}}</$link>&nbsp;&nbsp;&nbsp;<$macrocall $name="copy-to-clipboard" src={{!!title}} />
+
+</$list>
+
+[[ProjectsOverview|$:/tags/ITKG/ProjectsOverview]]&nbsp;&nbsp;[[config|$:/config/ViewTemplate/ProjectsOverview]]
+
+<$edit-text tiddler="$:/config/ViewTemplate/ProjectsOverview" field="text" tag=textarea class="w-100" />
+
+<$list filter="[all[tiddlers+shadows]tag[$:/tags/ITKG/ProjectsOverview]]">
+
+<$link>{{!!caption}}</$link>&nbsp;&nbsp;&nbsp;<$macrocall $name="copy-to-clipboard" src={{!!title}} />
+
+</$list>
+

--- a/src/intention-tower-knowledge-graph/ControlPanel/Tags.tid
+++ b/src/intention-tower-knowledge-graph/ControlPanel/Tags.tid
@@ -1,0 +1,50 @@
+title: $:/plugins/linonetwo/intention-tower-knowledge-graph/Settings/Tags
+caption: Tags
+tags: $:/tags/intention-tower-knowledge-graph/Settings
+order: 1
+
+\define single-text-tag-editor(typeName)
+\whitespace trim
+<div class="itkg-setting-tags-item">
+  <$let
+    currentTiddler="$:/plugins/linonetwo/intention-tower-knowledge-graph/Config/$typeName$-tag"
+    palette={{$:/palette}}
+    tempTitle=<<qualify "edit-$typeName$">>
+    tabIndex={{$:/config/EditTabIndex}}
+    cancelPopups="yes"
+  >
+    <$macrocall $name="tag" tag={{$:/plugins/linonetwo/intention-tower-knowledge-graph/Config/$typeName$-tag}} />
+
+    <$edit-text tiddler=<<tempTitle>> tag="input" field="text" placeholder={{$:/language/EditTemplate/Tags/Add/Placeholder}} />
+
+    <$button>
+      <$action-setfield tiddler=<<currentTiddler>> text={{{ [<tempTitle>get[text]] }}}>
+        <$action-setfield tiddler=<<tempTitle>> text="" />
+      </$action-setfield>
+
+      {{$:/language/EditTemplate/Tags/Add/Button}}
+    </$button>
+    
+  </$let> 
+</div>
+\end
+
+
+!! 标签
+
+!!! 标注项目关键节点的标签
+
+
+意义：<<single-text-tag-editor intention>>
+
+项目：<<single-text-tag-editor project>>
+
+任务：<<single-text-tag-editor task>>
+
+''修改了任务标签后，原先带有`任务`标签的条目并不会自动修改过来，需要手动修改处理。''
+
+!!! 新建日历记录时的标签
+
+在新建和一个任务相关的日历项目时，可以设置自动添加日历项目的类型标签，例如「解决问题」。
+
+日历记录额外标签：<<single-text-tag-editor default-calendar-entry>>

--- a/src/intention-tower-knowledge-graph/SuperTags/任务.tid
+++ b/src/intention-tower-knowledge-graph/SuperTags/任务.tid
@@ -1,5 +1,4 @@
-tags: $:/TraitTag/TMO/Task
 title: 任务
 type: text/vnd.tiddlywiki
 
-这是一个提供「任务」相关表单字段的「[[超级标签|https://tiddly-gittly.github.io/super-tag/]]」。
+这是一个提供「任务」相关表单字段的「[[超级标签|https://tiddly-gittly.github.io/super-tag/]]」。如果修改了那就是{{$:/plugins/linonetwo/intention-tower-knowledge-graph/Config/task-tag}}。

--- a/src/intention-tower-knowledge-graph/ViewTemplate/ProjectsOverview/ProjectsOverview.tid
+++ b/src/intention-tower-knowledge-graph/ViewTemplate/ProjectsOverview/ProjectsOverview.tid
@@ -1,4 +1,4 @@
 title: $:/plugins/linonetwo/intention-tower-knowledge-graph/ViewTemplate/ProjectsOverview
 
 <!-- similar to $:/plugins/linonetwo/intention-tower-knowledge-graph/ViewTemplate/UnderProject -->
-<<tabs "[all[tiddlers+shadows]tag[$:/tags/ITKG/ProjectsOverview]]" "$:/plugins/linonetwo/intention-tower-knowledge-graph/ViewTemplate/PriorityTaskDynamicTable" >>
+<<tabs "[all[tiddlers+shadows]tag[$:/tags/ITKG/ProjectsOverview]] -[enlist{$:/config/ViewTemplate/ProjectsOverview}]" "$:/plugins/linonetwo/intention-tower-knowledge-graph/ViewTemplate/PriorityTaskDynamicTable" >>

--- a/src/intention-tower-knowledge-graph/ViewTemplate/UnderIntention/AddIntention.tid
+++ b/src/intention-tower-knowledge-graph/ViewTemplate/UnderIntention/AddIntention.tid
@@ -2,6 +2,4 @@ title: $:/plugins/linonetwo/intention-tower-knowledge-graph/ViewTemplate/UnderIn
 caption: {{$:/core/images/tag-button}} 添加意义
 tags: $:/tags/ITKG/UnderIntention
 
-<$reveal state="$:/config/intention-tower-knowledge-graph/ViewTemplate/UnderIntention/AddIntention" type="match" text="show">
 {{||$:/core/ui/EditTemplate/tags}}
-</$reveal>

--- a/src/intention-tower-knowledge-graph/ViewTemplate/UnderIntention/ProjectDynamicTable.tid
+++ b/src/intention-tower-knowledge-graph/ViewTemplate/UnderIntention/ProjectDynamicTable.tid
@@ -4,8 +4,4 @@ tags: $:/tags/ITKG/UnderIntention
 
 \import [[$:/plugins/linonetwo/intention-tower-knowledge-graph/filters/leaf-task]]
 
-<$reveal state="$:/config/intention-tower-knowledge-graph/ViewTemplate/ProjectDynamicTable" type="match" text="show">
-
 <$macrocall $name=aggregation caption="项目列表" filter=<<get-non-completed-leaf-projects>> defaultFields={{$:/plugins/linonetwo/intention-tower-knowledge-graph/Config/defaultFields-ProjectDynamicTable}} class="w-100" state="ITKG-ProjectDynamicTable-state" />
-
-</$reveal>

--- a/src/intention-tower-knowledge-graph/ViewTemplate/UnderIntention/ProjectsUnderThisIntentionFlowChartEcharts.tid
+++ b/src/intention-tower-knowledge-graph/ViewTemplate/UnderIntention/ProjectsUnderThisIntentionFlowChartEcharts.tid
@@ -11,8 +11,4 @@ tags: $:/tags/ITKG/UnderIntention
 />
 \end
 
-<$reveal state="$:/config/intention-tower-knowledge-graph/ViewTemplate/ProjectsUnderThisIntentionFlowChartEcharts" type="match" text="show">
-
 <<echarts-with-subfilter>>
-
-</$reveal>

--- a/src/intention-tower-knowledge-graph/ViewTemplate/UnderIntention/UnderIntention.tid
+++ b/src/intention-tower-knowledge-graph/ViewTemplate/UnderIntention/UnderIntention.tid
@@ -8,7 +8,7 @@ tags: $:/tags/ViewTemplate
 
   <<create-project-under-current-tiddler>>
 
-  <<tabs "[all[tiddlers+shadows]tag[$:/tags/ITKG/UnderIntention]]" "$:/plugins/linonetwo/intention-tower-knowledge-graph/ViewTemplate/ProjectsUnderThisIntentionFlowChartEcharts" >>
+  <<tabs "[all[tiddlers+shadows]tag[$:/tags/ITKG/UnderIntention]] -[enlist{$:/config/ViewTemplate/UnderIntention}]" "$:/plugins/linonetwo/intention-tower-knowledge-graph/ViewTemplate/ProjectsUnderThisIntentionFlowChartEcharts" >>
 
   </$list>
 </$let>

--- a/src/intention-tower-knowledge-graph/ViewTemplate/UnderProject/AddIntention.tid
+++ b/src/intention-tower-knowledge-graph/ViewTemplate/UnderProject/AddIntention.tid
@@ -2,6 +2,4 @@ title: $:/plugins/linonetwo/intention-tower-knowledge-graph/ViewTemplate/UnderPr
 caption: {{$:/core/images/tag-button}} 添加意义
 tags: $:/tags/ITKG/UnderProject
 
-<$reveal state="$:/config/intention-tower-knowledge-graph/ViewTemplate/UnderProject/AddIntention" type="match" text="show">
 {{||$:/core/ui/EditTemplate/tags}}
-</$reveal>

--- a/src/intention-tower-knowledge-graph/ViewTemplate/UnderProject/CalendarThisYear.tid
+++ b/src/intention-tower-knowledge-graph/ViewTemplate/UnderProject/CalendarThisYear.tid
@@ -8,8 +8,6 @@ tags: $:/tags/ITKG/UnderProject
 <$calendar filter="[all[]in-tagtree-of:inclusive[$currentTag$]field:calendarEntry[yes]]" readonly="yes" initialView="listYear" hideToolbar="yes" />
 \end
 
-<$reveal state="$:/config/intention-tower-knowledge-graph/ViewTemplate/CalendarEntry/CalendarThisYear" type="match" text="show">
-
 项目下共工作 {{{ 
 [all[]in-tagtree-of:inclusive<currentTiddler>field:calendarEntry[yes]]
   :map[subfilter<getTimeForEntry>]
@@ -18,5 +16,3 @@ tags: $:/tags/ITKG/UnderProject
 
 
 <$macrocall $name="calendarWithCurrentTiddler" currentTag=<<currentTiddler>>/>
-
-</$reveal>

--- a/src/intention-tower-knowledge-graph/ViewTemplate/UnderProject/TaskDynamicTable.tid
+++ b/src/intention-tower-knowledge-graph/ViewTemplate/UnderProject/TaskDynamicTable.tid
@@ -5,8 +5,5 @@ tags: $:/tags/ITKG/UnderProject
 \import [[$:/plugins/linonetwo/intention-tower-knowledge-graph/filters/leaf-task]]
 
 \define caption() 优先待办列表 <$count filter=<<get-non-completed-leaf-tasks>> />
-<$reveal state="$:/config/intention-tower-knowledge-graph/ViewTemplate/TaskDynamicTable" type="match" text="show">
 
 <$macrocall $name=aggregation caption=<<caption>> filter=<<get-non-completed-leaf-tasks>> defaultFields={{$:/plugins/linonetwo/intention-tower-knowledge-graph/Config/defaultFields-TaskDynamicTable}} class="w-100" state="ITKG-TaskDynamicTable-state" />
-
-</$reveal>

--- a/src/intention-tower-knowledge-graph/ViewTemplate/UnderProject/UnderProject.tid
+++ b/src/intention-tower-knowledge-graph/ViewTemplate/UnderProject/UnderProject.tid
@@ -8,7 +8,7 @@ tags: $:/tags/ViewTemplate
 
   <<create-task-under-current-tiddler>>
 
-  <<tabs "[all[tiddlers+shadows]tag[$:/tags/ITKG/UnderProject]] [all[tiddlers+shadows]tag[$:/tags/ITKG/UnderTask]]" "$:/plugins/linonetwo/intention-tower-knowledge-graph/ViewTemplate/TaskDynamicTable" >>
+  <<tabs "[all[tiddlers+shadows]tag[$:/tags/ITKG/UnderProject]] [all[tiddlers+shadows]tag[$:/tags/ITKG/UnderTask]] -[enlist{$:/config/ViewTemplate/UnderProject}] -[enlist{$:/config/ViewTemplate/UnderTask}]" "$:/plugins/linonetwo/intention-tower-knowledge-graph/ViewTemplate/TaskDynamicTable" >>
 
   </$list>
 </$let>

--- a/src/intention-tower-knowledge-graph/ViewTemplate/UnderTask/AddProject.tid
+++ b/src/intention-tower-knowledge-graph/ViewTemplate/UnderTask/AddProject.tid
@@ -2,8 +2,4 @@ title: $:/plugins/linonetwo/intention-tower-knowledge-graph/ViewTemplate/AddProj
 caption: {{$:/core/images/tag-button}} 添加所在项目
 tags: $:/tags/ITKG/UnderTask
 
-<$reveal state="$:/config/intention-tower-knowledge-graph/ViewTemplate/AddProject" type="match" text="show">
-
 {{||$:/core/ui/EditTemplate/tags}}
-
-</$reveal>

--- a/src/intention-tower-knowledge-graph/ViewTemplate/UnderTask/CalendarEntry/AddCalendarEntryThisWeek.tid
+++ b/src/intention-tower-knowledge-graph/ViewTemplate/UnderTask/CalendarEntry/AddCalendarEntryThisWeek.tid
@@ -2,8 +2,4 @@ title: $:/plugins/linonetwo/intention-tower-knowledge-graph/ViewTemplate/AddCale
 caption: {{$:/plugins/linonetwo/tw-calendar/Images/CalendarWeek}} 调整本周任务
 tags: $:/tags/ITKG/CalendarEntry
 
-<$reveal state="$:/config/intention-tower-knowledge-graph/ViewTemplate/AddCalendarEntryThisWeek" type="match" text="show">
-
 <$calendar defaultTags={{{ [<currentTiddler>] [{$:/plugins/linonetwo/intention-tower-knowledge-graph/Config/default-calendar-entry-tag}] +[join[ ]] }}} hideToolbar="yes" height="600px" initialView="timeGridWeek" filter="[all[tiddlers]!is[system]field:calendarEntry[yes]]" />
-
-</$reveal>

--- a/src/intention-tower-knowledge-graph/ViewTemplate/UnderTask/CalendarEntry/AddCalendarEntryToday.tid
+++ b/src/intention-tower-knowledge-graph/ViewTemplate/UnderTask/CalendarEntry/AddCalendarEntryToday.tid
@@ -4,7 +4,6 @@ tags: $:/tags/ITKG/CalendarEntry
 
 \import [[$:/plugins/linonetwo/intention-tower-knowledge-graph/filters/time]]
 
-<$reveal state="$:/config/intention-tower-knowledge-graph/ViewTemplate/AddCalendarEntryToday" type="match" text="show">
 
 今日仅工作 {{{ 
 [all[]tag<currentTiddler>days:startDate[0]field:calendarEntry[yes]]
@@ -13,5 +12,3 @@ tags: $:/tags/ITKG/CalendarEntry
 }}} 小时！（包含计划中未做的）
 
 <$calendar defaultTags={{{ [<currentTiddler>] [{$:/plugins/linonetwo/intention-tower-knowledge-graph/Config/default-calendar-entry-tag}] +[join[ ]] }}} hideToolbar="yes" height="600px" initialView="timeGridDay" filter="[all[tiddlers]!is[system]days:startDate[0]field:calendarEntry[yes]]" />
-
-</$reveal>

--- a/src/intention-tower-knowledge-graph/ViewTemplate/UnderTask/CalendarEntry/CalendarEntry.tid
+++ b/src/intention-tower-knowledge-graph/ViewTemplate/UnderTask/CalendarEntry/CalendarEntry.tid
@@ -2,8 +2,4 @@ title: $:/plugins/linonetwo/intention-tower-knowledge-graph/ViewTemplate/Calenda
 caption: {{$:/plugins/linonetwo/tw-calendar/tiddlywiki-ui/Images/GoToCalendarImage}} 日历记录
 tags: $:/tags/ITKG/UnderTask
 
-<$reveal state="$:/config/intention-tower-knowledge-graph/ViewTemplate/CalendarEntry" type="match" text="show">
-
-<<tabs "[all[tiddlers+shadows]tag[$:/tags/ITKG/CalendarEntry]]" "$:/plugins/linonetwo/intention-tower-knowledge-graph/ViewTemplate/AddCalendarEntryToday" >>
-
-</$reveal>
+<<tabs "[all[tiddlers+shadows]tag[$:/tags/ITKG/CalendarEntry]] -[enlist{$:/config/ViewTemplate/CalendarEntry}]" "$:/plugins/linonetwo/intention-tower-knowledge-graph/ViewTemplate/AddCalendarEntryToday" >>

--- a/src/intention-tower-knowledge-graph/ViewTemplate/UnderTask/CalendarEntry/CalendarThisWeek.tid
+++ b/src/intention-tower-knowledge-graph/ViewTemplate/UnderTask/CalendarEntry/CalendarThisWeek.tid
@@ -6,6 +6,4 @@ tags: $:/tags/ITKG/CalendarEntry
 <$calendar filter="[all[]tag[$currentTag$]field:calendarEntry[yes]]" readonly="yes" initialView="listWeek" hideToolbar="yes" />
 \end
 
-<$reveal state="$:/config/intention-tower-knowledge-graph/ViewTemplate/CalendarEntry/CalendarThisWeek" type="match" text="show">
 <$macrocall $name="calendarWithCurrentTiddler" currentTag=<<currentTiddler>>/>
-</$reveal>

--- a/src/intention-tower-knowledge-graph/ViewTemplate/UnderTask/TaskContext.tid
+++ b/src/intention-tower-knowledge-graph/ViewTemplate/UnderTask/TaskContext.tid
@@ -13,8 +13,6 @@ tags: $:/tags/ITKG/UnderTask
 />
 \end
 
-<$reveal state="$:/config/intention-tower-knowledge-graph/ViewTemplate/TaskContext" type="match" text="show">
-
 <!-- Show all parent tags of current tiddler (all tiddlers that with current tiddler in the tags tree), that with Task, Intention, and Project, but exclude these meta tags themselves -->
 <$list filter="[all[current]tagstree[]!is[system]tag{$:/plugins/linonetwo/intention-tower-knowledge-graph/Config/task-tag}] :or[all[current]tagstree[]!is[system]tag{$:/plugins/linonetwo/intention-tower-knowledge-graph/Config/intention-tag}] -[{$:/plugins/linonetwo/intention-tower-knowledge-graph/Config/task-tag}] -[{$:/plugins/linonetwo/intention-tower-knowledge-graph/Config/project-tag}] -[{$:/plugins/linonetwo/intention-tower-knowledge-graph/Config/intention-tag}]" counter="counter1">
   <$link><<currentTiddler>></$link>
@@ -57,5 +55,3 @@ tags: $:/tags/ITKG/UnderTask
 <$list filter="[<graphRootTiddler>taggingtree[]filter<filter-is-new-task>count[]compare:number:gt[0]then[yes]]">
   <$flowchart tiddler=<<graphRootTiddler>> height="600px" $template-tags={{$:/plugins/linonetwo/intention-tower-knowledge-graph/Config/task-tag}} subfilter="[filter<filter-is-new-task>]" />
 </$list>
-
-</$reveal>

--- a/src/intention-tower-knowledge-graph/ViewTemplate/UnderTask/UnderTask.tid
+++ b/src/intention-tower-knowledge-graph/ViewTemplate/UnderTask/UnderTask.tid
@@ -15,7 +15,7 @@ tags: $:/tags/ViewTemplate
   
  
 
-  <<tabs "[all[tiddlers+shadows]tag[$:/tags/ITKG/UnderTask]]" "$:/plugins/linonetwo/intention-tower-knowledge-graph/ViewTemplate/TaskContext" >>
+  <<tabs "[all[tiddlers+shadows]tag[$:/tags/ITKG/UnderTask]] -[enlist{$:/config/ViewTemplate/UnderTask}]" "$:/plugins/linonetwo/intention-tower-knowledge-graph/ViewTemplate/TaskContext" >>
 
   </$list>
 </$let>

--- a/wiki/tiddlers/Index.tid
+++ b/wiki/tiddlers/Index.tid
@@ -22,4 +22,4 @@ type: text/vnd.tiddlywiki
 
 依赖插件有："$:/plugins/kookma/shiraz", "$:/plugins/linonetwo/flow-chart", "$:/plugins/yaisog/taggingtree-filter", "$:/plugins/yaisog/tagstree-filter", "$:/plugins/linonetwo/in-tagtree-of", "$:/plugins/xp/aggregation",$:/plugins/Gk0Wk/echarts", "$:/plugins/linonetwo/super-tag", "$:/plugins/linonetwo/tw-calendar","$:/plugins/kixam/datepicker","$:/plugins/kixam/moment"。如果CPL没有自动安装，请手动安装。
 
-其中$:/plugins/xp/aggregation需要更新到0.5.0版本。
+其中$:/plugins/xp/aggregation需要更新到0.5.0版本或更高的版本。


### PR DESCRIPTION
改动挺多。把之前的reveal控制内容都删除了。然后把设置也修改成了tabs的样式。

里面有个超级标签，我加到`$:/plugins/linonetwo/intention-tower-knowledge-graph/Config/task-tag`里去了。因为怕用户不能察觉到而在修改了任务条目后，无法显示表单。

我现在多少应该也明白了回归问题是什么意思了。从可以控制选项卡，到添加用reveal控制选项卡内容，再到现在用enlist控制选项卡。如果我技术再成熟一点，可能一开始就应该想到的。而不是现在这样折腾来折腾去。

目前是让用户自己去复制然后添加到上面的空白框里。如果我技术再成熟或者我花的时间再多一点，或许也可以解决掉，直接用checkbox或者button来处理。但时间成本太高了。知识的诅咒固然存在，但也不是所有的知识都要因传播而带上诅咒。也不能因为有这样的诅咒就把应用做成傻瓜式，那这样的品味只能是没品味。