### PR TITLE
fix: 修复super-tag标签问题

### DIFF
--- a/src/intention-tower-knowledge-graph/Config/task-tag.tid
+++ b/src/intention-tower-knowledge-graph/Config/task-tag.tid
@@ -1,4 +1,4 @@
 title: $:/plugins/linonetwo/intention-tower-knowledge-graph/Config/task-tag
-tags: $:/TraitTag/TMO/Task
+
 
 任务

--- a/src/intention-tower-knowledge-graph/ControlPanel/Tags.tid
+++ b/src/intention-tower-knowledge-graph/ControlPanel/Tags.tid
@@ -41,7 +41,12 @@ order: 1
 
 任务：<<single-text-tag-editor task>>
 
-''修改了任务标签后，原先带有`任务`标签的条目并不会自动修改过来，需要手动修改处理。''
+''修改了任务标签后，原先带有`任务`标签的条目并不会自动修改过来，需要手动修改处理。并点击下面按钮完成超级标签转换。''
+
+<$button>
+<$action-setfield $tiddler="任务" title={{$:/plugins/linonetwo/intention-tower-knowledge-graph/Config/task-tag}} />
+修改任务的超级标签
+</$button>
 
 !!! 新建日历记录时的标签
 

--- a/src/intention-tower-knowledge-graph/SuperTags/任务.tid
+++ b/src/intention-tower-knowledge-graph/SuperTags/任务.tid
@@ -1,4 +1,5 @@
 title: 任务
 type: text/vnd.tiddlywiki
+tags: $:/TraitTag/TMO/Task
 
 这是一个提供「任务」相关表单字段的「[[超级标签|https://tiddly-gittly.github.io/super-tag/]]」。如果修改了那就是{{$:/plugins/linonetwo/intention-tower-knowledge-graph/Config/task-tag}}。


### PR DESCRIPTION
紧急修复。我发现super-tag插件只能按照插件名称来处理，无法传递过去。所以增加一个按钮来提示修改。

因为插件机制，所以插件自带的任务并不会改掉。